### PR TITLE
Use Got instead of Request

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "bluebird": "^3.4.6",
     "debug": "^2.3.3",
     "flatten": "^1.0.2",
+    "got": "^6.6.3",
     "lodash.partial": "^4.2.1",
     "object-assign": "^4.1.0",
-    "plug-login": "^0.4.0",
+    "plug-login": "^1.0.0",
     "plug-socket": "^0.1.0",
-    "request": "^2.60.0",
     "unescape": "^0.2.0"
   },
   "devDependencies": {

--- a/test/plug.dj.js
+++ b/test/plug.dj.js
@@ -1,15 +1,11 @@
-const request = require('request')
+const got = require('got')
 
 describe('plug.dj', () => {
-  it('is reachable', (done) => {
-    request('https://plug.dj/', (e, resp, body) => {
-      if (e) {
-        throw e
-      }
-      if (body.indexOf('<title>maintenance') !== -1) {
+  it('is reachable', () => {
+    return got('https://plug.dj/').then((response) => {
+      if (response.body.indexOf('<title>maintenance') !== -1) {
         throw new Error('plug.dj is currently in maintenance mode.')
       }
-      done()
     })
   })
 })


### PR DESCRIPTION
`request` is quite large and plug-login v1.0.0 uses Got as well. Plus, `got` uses promises itself, so it fits right in.