### PR TITLE
Fixed Small Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install --save miniplug
 ```js
 const miniplug = require('miniplug')
 
-const mp = miniplug({ user: 'admin@plug.dj', password: 'hunter2' })
+const mp = miniplug({ email: 'admin@plug.dj', password: 'hunter2' })
 // Join a room
 mp.join('tastycat').then((room) => {
   mp.chat(`Hello ${room.name}! :wave:`)


### PR DESCRIPTION
bot would login as guest if I used `user`, but when I changed it to `email`, it worked. it's also stated as `email` in the docs https://github.com/goto-bus-stop/miniplug/blob/master/docs/API.md#mp--miniplugopts