### PR TITLE
Fallback for user object in vote event

### DIFF
--- a/src/plugins/vote.js
+++ b/src/plugins/vote.js
@@ -18,7 +18,7 @@ export default function votePlugin (opts = {}) {
         uid: i,
         vote: v
       })
-      const user = mp.user(i)
+      const user = mp.user(i) || mp.wrapUser({ id: i })
       mp.emit('vote', {
         user,
         vote: v


### PR DESCRIPTION
Noticed some undefined user objects, but the ID should still be provided, so a fallback to allow most miniplug methods would be very useful.

The front end on plug.dj seems to not emit this event to the API (but still takes the vote into account internally). I didn't add that but it might be something worth considering?