### PR TITLE
Throw more useful errors, fixes #37

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2308,6 +2308,7 @@ All error objects have the following properties:
 
  - `message` - A human-readable string describing the reason for the error.
  - `status` - A status code from plug.dj.
+ - `response` - The HTTP response object from [got](https://github.com/sindresorhus/got#goturl-options).
  - `cause` - The error that was wrapped, usually one from [got](https://github.com/sindresorhus/got#errors).
 
 <a id="error-requesterror"></a>

--- a/docs/API.md
+++ b/docs/API.md
@@ -180,6 +180,7 @@
  - [Product Categories](#productcategories)
  - [REST methods](#mp-rest)
  - [Events](#events)
+ - [Errors](#errors)
 
 ## Introduction
 
@@ -2286,3 +2287,56 @@ mp.on('waitlistUpdate', (next, previous) => {
   console.log('I moved from', previous.positionOf(me), 'to', next.positionOf(me))
 })
 ```
+
+<a id="errors"></a>
+# Errors
+
+Miniplug wraps errors from the plug.dj API in custom error classes.
+Specific types of errors can be caught using Bluebird's `catch` function:
+
+```js
+const miniplug = require('miniplug')
+
+const mp = miniplug({ /* credentials */ })
+mp.purchaseNameChange('Test Name')
+  .catch(miniplug.NotEnoughPPError, (err) => {
+    console.error('You do not have enough Plug Points to change your name.')
+  })
+```
+
+All error objects have the following properties:
+
+ - `message` - A human-readable string describing the reason for the error.
+ - `status` - A status code from plug.dj.
+ - `cause` - The error that was wrapped, usually one from [got](https://github.com/sindresorhus/got#errors).
+
+<a id="error-requesterror"></a>
+## RequestError
+
+A generic error that indicates that you have tried to do something impossible.
+
+<a id="error-badloginerror"></a>
+## BadLoginError
+
+The username/password combination was incorrect.
+
+<a id="error-notauthorizederror"></a>
+## NotAuthorizedError
+
+The bot account does not have permission to do this thing. Perhaps because the
+thing requires you to be logged in, or to be a certain rank in the room.
+
+<a id="error-notfounderror"></a>
+## NotFoundError
+
+The thing you are looking for does not exist.
+
+<a id="error-novalidplaylisterror"></a>
+## NoValidPlaylistError
+
+The user to be added to the waitlist does not have a valid playlist.
+
+<a id="error-notenoughpperror"></a>
+## NotEnoughPPError
+
+The bot account does not have enough Plug Points to purchase this thing.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "bluebird": "^3.4.6",
+    "create-error-class": "^3.0.2",
     "debug": "^2.3.3",
     "got": "^6.6.3",
     "plug-login": "^1.0.0",

--- a/src/errors.js
+++ b/src/errors.js
@@ -9,13 +9,21 @@ function setup (response, cause) {
   this.cause = cause
 }
 
+function setupFundsPP (response, cause) {
+  setup.call(this, response, cause)
+  this.message = 'You don\'t have enough Plug Points to unlock this.'
+}
+
 export const RequestError = createErrorClass('RequestError', setup)
+export const BadLoginError = createErrorClass('BadLoginError', setup)
 export const NotAuthorizedError = createErrorClass('NotAuthorizedError', setup)
 export const NotFoundError = createErrorClass('NotFoundError', setup)
 export const NoValidPlaylistError = createErrorClass('NoValidPlaylistError', setup)
+export const NotEnoughPPError = createErrorClass('NotEnoughPPError', setupFundsPP)
 
 const statusToError = {
   requestError: RequestError,
+  badLogin: BadLoginError,
   notAuthorized: NotAuthorizedError,
   notFound: NotFoundError,
   noValidPlaylist: NoValidPlaylistError,
@@ -23,6 +31,11 @@ const statusToError = {
 
 export function wrapResponseError(response, cause) {
   const { status, data } = response.body
+  // Special cases
+  if (status === 'requestError' && data && data[0] === 'fundsPP') {
+    return new NotEnoughPPError(response, cause)
+  }
+
   const ErrorClass = statusToError[status]
   if (ErrorClass) {
     return new ErrorClass(response, cause)

--- a/src/errors.js
+++ b/src/errors.js
@@ -14,12 +14,12 @@ function setupFundsPP (response, cause) {
   this.message = 'You don\'t have enough Plug Points to unlock this.'
 }
 
-export const RequestError = createErrorClass('RequestError', setup)
-export const BadLoginError = createErrorClass('BadLoginError', setup)
-export const NotAuthorizedError = createErrorClass('NotAuthorizedError', setup)
-export const NotFoundError = createErrorClass('NotFoundError', setup)
-export const NoValidPlaylistError = createErrorClass('NoValidPlaylistError', setup)
-export const NotEnoughPPError = createErrorClass('NotEnoughPPError', setupFundsPP)
+const RequestError = createErrorClass('RequestError', setup)
+const BadLoginError = createErrorClass('BadLoginError', setup)
+const NotAuthorizedError = createErrorClass('NotAuthorizedError', setup)
+const NotFoundError = createErrorClass('NotFoundError', setup)
+const NoValidPlaylistError = createErrorClass('NoValidPlaylistError', setup)
+const NotEnoughPPError = createErrorClass('NotEnoughPPError', setupFundsPP)
 
 const statusToError = {
   requestError: RequestError,
@@ -27,6 +27,15 @@ const statusToError = {
   notAuthorized: NotAuthorizedError,
   notFound: NotFoundError,
   noValidPlaylist: NoValidPlaylistError,
+}
+
+export const errorClasses = {
+  RequestError,
+  BadLoginError,
+  NotAuthorizedError,
+  NotFoundError,
+  NoValidPlaylistError,
+  NotEnoughPPError
 }
 
 export function wrapResponseError(response, cause) {

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,32 @@
+import createErrorClass from 'create-error-class'
+
+function setup (response, cause) {
+  this.message = response.body.data
+    && response.body.data[0]
+    || cause.message
+  this.status = response.body.status
+  this.response = response
+  this.cause = cause
+}
+
+export const RequestError = createErrorClass('RequestError', setup)
+export const NotAuthorizedError = createErrorClass('NotAuthorizedError', setup)
+export const NotFoundError = createErrorClass('NotFoundError', setup)
+export const NoValidPlaylistError = createErrorClass('NoValidPlaylistError', setup)
+
+const statusToError = {
+  requestError: RequestError,
+  notAuthorized: NotAuthorizedError,
+  notFound: NotFoundError,
+  noValidPlaylist: NoValidPlaylistError,
+}
+
+export function wrapResponseError(response, cause) {
+  const { status, data } = response.body
+  const ErrorClass = statusToError[status]
+  if (ErrorClass) {
+    return new ErrorClass(response, cause)
+  }
+  setup.call(cause, response, cause)
+  return cause
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import createDebug from 'debug'
 
 import { partial } from './util'
 import * as constants from './constants'
+import { errorClasses } from './errors'
 import createBackoff from './createBackoff'
 import dataModelPlugin from './plugins/wrappers'
 import httpPlugin from './plugins/http'
@@ -43,7 +44,8 @@ Object.assign(miniplug, {
   storePlugin,
   systemPlugin,
   votePlugin,
-  ...constants
+  ...constants,
+  ...errorClasses
 })
 
 export default miniplug

--- a/src/plugins/http.js
+++ b/src/plugins/http.js
@@ -1,5 +1,6 @@
 import got from 'got'
 import createDebug from 'debug'
+import { wrapResponseError } from '../errors'
 
 const debug = createDebug('miniplug:http')
 
@@ -30,6 +31,12 @@ export default function httpPlugin (httpOpts) {
             throw new Error(resp.body.data.length ? resp.body.data[0] : resp.body.status)
           }
           return resp.body.data
+        })
+        .catch((err) => {
+          if (err && err.response) {
+            throw wrapResponseError(err.response, err)
+          }
+          throw err
         })
     )
 


### PR DESCRIPTION
Still have to check what other types of errors there are. A lot of different kinds of errors do return the same `requestError` response status unfortunately, but I'll leave those be for now.

Should also expose the error classes on the main module export so you can do `.catch(NoValidPlaylistError, err => {})` and handle them that way.