### PR TITLE
Add `userByName`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -18,6 +18,7 @@
  - [mp.getRoomState()](#mp-getroomstate)
  - [mp.me()](#mp-me)
  - [mp.user(id)](#mp-user)
+ - [mp.userByName(name)](#mp-userbyname)
  - [mp.users()](#mp-users)
  - [mp.guests()](#mp-guests)
  - [mp.getMe()](#mp-getme)
@@ -374,6 +375,30 @@ requested user is not in the room.
 
 ```js
 console.log('Some other user:', mp.user(123456).username)
+```
+
+<a id="mp-userbyname"></a>
+## mp.userByName(name): [User](#class-user)
+
+Synchronously get a user object from the current room, identified by the username.
+Returns `null` if the requested user is not in the room.
+
+Usernames are case sensitive.
+
+```js
+// An `!id` command that shows a user's ID
+// Usage: `!id @Username`, eg `!id @Tastybot`
+mp.on('chat', (message) => {
+  if (message.startsWith('!id @')) {
+    const name = message.slice(5)
+    const user = mp.userByName(name)
+    if (user) {
+      message.reply(`${user.mention()}'s ID is ${user.id}`)
+    } else {
+      message.reply(`I don't know the user "${name}"`)
+    }
+  }
+})
 ```
 
 <a id="mp-users"></a>

--- a/src/plugins/users.js
+++ b/src/plugins/users.js
@@ -88,12 +88,14 @@ export default function usersPlugin () {
     })
 
     const me = () => mp[currentUser]
-    const user = (id) => {
-      if (mp[currentUser] && id === mp[currentUser].id) {
+    const userByProp = (prop) => (value) => {
+      if (mp[currentUser] && value === mp[currentUser][prop]) {
         return mp[currentUser]
       }
-      return mp[currentUsers].find((user) => user.id === id)
+      return mp[currentUsers].find((user) => user[prop] === value)
     }
+    const user = userByProp('id')
+    const userByName = userByProp('username')
     // TODO May want to include `me()` in the `users()` list in v2.0.0. I'm not
     // sure which is more expected.
     const users = () => mp[currentUsers]
@@ -130,6 +132,7 @@ export default function usersPlugin () {
       // local
       me,
       user,
+      userByName,
       users,
       guests,
       // remote

--- a/test/users.js
+++ b/test/users.js
@@ -21,7 +21,7 @@ test('Get the current user', async (t) => {
 })
 
 test('Get a user who is currently in the room', async (t) => {
-  t.plan(3)
+  t.plan(5)
 
   nock.post('/_/rooms/join').reply(200, require('./mocks/rooms/join.json'))
   nock.get('/_/rooms/state').reply(200, require('./mocks/rooms/state.json'))
@@ -36,4 +36,7 @@ test('Get a user who is currently in the room', async (t) => {
   t.ok(mp.user(4103894), 'should return user who is in the room')
   t.notok(mp.user(123456), 'should not return user who is not in the room')
   t.ok(mp.user(555555), 'should get the current user, issue #35')
+
+  t.ok(mp.userByName('Tastybot'), 'should find users by their name')
+  t.notok(mp.userByName('tastybot'), 'should treat usernames case sensitively')
 })


### PR DESCRIPTION

Synchronously get a user object from the current room, identified by the username.
Returns `null` if the requested user is not in the room.

Usernames are case sensitive.

```js
// An `!id` command that shows a user's ID
// Usage: `!id @Username`, eg `!id @Tastybot`
mp.on('chat', (message) => {
  if (message.startsWith('!id @')) {
    const name = message.slice(5)
    const user = mp.userByName(name)
    if (user) {
      message.reply(`${user.mention()}'s ID is ${user.id}`)
    } else {
      message.reply(`I don't know the user "${name}"`)
    }
  }
})
```
