### PR TITLE
http: Use `keepAlive`

### DIFF
--- a/src/plugins/http.js
+++ b/src/plugins/http.js
@@ -1,7 +1,9 @@
 import got from 'got'
 import createDebug from 'debug'
+import { Agent } from 'https'
 import { wrapResponseError } from '../errors'
 
+const agent = new Agent({ keepAlive: true })
 const debug = createDebug('miniplug:http')
 
 export default function httpPlugin (httpOpts) {
@@ -17,6 +19,7 @@ export default function httpPlugin (httpOpts) {
         .tap(() => debug(opts.method, url, opts.body || opts.query))
         .then((session) =>
           got(`${httpOpts.host}/_/${url}`, {
+            agent,
             headers: {
               cookie: session.cookie,
               'content-type': 'application/json'


### PR DESCRIPTION
Use an https agent. Knocks down the time needed to set up https requests by a few milliseconds.

My nonscientific tests with:
```js
miniplug().join('tastycat')
```
indicate about 3500\~4500ms before this change, and 3100~3600ms after.