### PR TITLE
wrapUser consistency & modAddDj wrong format

### DIFF
--- a/src/data/chat.js
+++ b/src/data/chat.js
@@ -22,8 +22,7 @@ export default function wrapMessage (mp, message) {
     delete: partial(mp.deleteChat, message.cid),
 
     getUser () {
-      const user = mp.user && (mp.user(message.uid) ||
-        mp.wrapUser({ id: message.uid, username: message.un }))
+      const user = mp.user && mp.user(message.uid)
       return user ? Promise.resolve(user) : mp.getUser(message.uid)
     }
   })

--- a/src/data/chat.js
+++ b/src/data/chat.js
@@ -22,7 +22,8 @@ export default function wrapMessage (mp, message) {
     delete: partial(mp.deleteChat, message.cid),
 
     getUser () {
-      const user = mp.user && mp.user(message.uid)
+      const user = mp.user && (mp.user(message.uid) ||
+        mp.wrapUser({ id: message.uid, username: message.un }))
       return user ? Promise.resolve(user) : mp.getUser(message.uid)
     }
   })

--- a/src/data/waitlistBan.js
+++ b/src/data/waitlistBan.js
@@ -8,7 +8,8 @@ export default function wrapWaitlistBan (mp, data) {
 
   const ban = {
     user: mp.user(data.id) || mp.wrapUser({ id: data.id, username: data.username }),
-    moderator: mp.user(data.moderatorID) || mp.userByName(data.moderator) || null,
+    moderator: mp.user(data.moderatorID) || mp.userByName(data.moderator) || 
+      mp.wrapUser({ id: data.moderatorID, username: data.moderator }),
     moderatorName: data.moderator,
     reason: data.reason,
     duration: data.duration,

--- a/src/data/waitlistBan.js
+++ b/src/data/waitlistBan.js
@@ -8,7 +8,7 @@ export default function wrapWaitlistBan (mp, data) {
 
   const ban = {
     user: mp.user(data.id) || mp.wrapUser({ id: data.id, username: data.username }),
-    moderator: mp.user(data.moderatorID) || mp.userByName(data.moderator) || 
+    moderator: mp.user(data.moderatorID) || mp.userByName(data.moderator) ||
       mp.wrapUser({ id: data.moderatorID, username: data.moderator }),
     moderatorName: data.moderator,
     reason: data.reason,

--- a/src/plugins/chat.js
+++ b/src/plugins/chat.js
@@ -24,7 +24,7 @@ export default function chatPlugin (opts) {
       debug('chatDelete', mi, c)
       mp.emit('chatDelete', {
         cid: c,
-        user: mp.user(mi)
+        user: mp.user(mi) || mp.wrapUser({ id: mi })
       })
     }
 

--- a/src/plugins/rooms.js
+++ b/src/plugins/rooms.js
@@ -20,7 +20,7 @@ export default function roomsPlugin () {
     //  * `roomProp` - Property name for the value on the miniplug room object.
     function addUpdateHandler (eventName, sockProp, roomProp) {
       mp.ws.on(eventName, (data, targetSlug) => {
-        const user = mp.user(data.u)
+        const user = mp.user(data.u) || mp.wrapUser({ id: data.u })
         const value = data[sockProp]
 
         debug(eventName, user && user.id, value)

--- a/src/plugins/vote.js
+++ b/src/plugins/vote.js
@@ -27,7 +27,7 @@ export default function votePlugin (opts = {}) {
 
     function onGrab (uid) {
       mp[currentGrabs].push(uid)
-      const user = mp.user(uid)
+      const user = mp.user(uid) || mp.wrapUser({ id: uid })
       mp.emit('grab', user)
     }
 

--- a/src/plugins/waitlist.js
+++ b/src/plugins/waitlist.js
@@ -33,9 +33,8 @@ export default function waitlistPlugin () {
 
     function onModAddDj (ref) {
       mp.emit('modAddDj', {
-        moderator: mp.user(ref.mi) || mp.wrapUser({ id: ref.mi }),
-        username: ref.t,
-        cycle: ref.m
+        moderator: mp.user(ref.mi) || mp.wrapUser({ id: ref.mi, username: ref.m }),
+        username: ref.t
       })
     }
 

--- a/src/plugins/waitlist.js
+++ b/src/plugins/waitlist.js
@@ -63,12 +63,12 @@ export default function waitlistPlugin () {
     function onDjListCycle ({ f, mi }) {
       mp.emit('waitlistCycle', {
         shouldCycle: f,
-        user: mp.user(mi)
+        user: mp.user(mi) || mp.wrapUser({ id: mi })
       })
     }
 
     function onDjListLocked ({ f, c, mi }) {
-      const user = mp.user(mi)
+      const user = mp.user(mi) || mp.wrapUser({ id: mi })
       mp.emit('waitlistLock', {
         locked: f,
         cleared: !!c,


### PR DESCRIPTION
Covered most (if not all) mp.user's that could end up in undefined if the user is ghosting. Allows for at least basic extended methods.

Also fixed an inconsistency caused by another mistake on the plugdocumentation repository. Submitted a fix there as well as submitting a fix here.