### PR TITLE
Add HistoryEntry#skip

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1181,6 +1181,8 @@ Remove the user from the waitlist or the DJ Booth.
 <a id="user-skip"></a>
 ### user.skip(historyId): Promise
 
+> Please use the [historyEntry.skip](#historyentry-skip) method instead.
+
 Skip the user. `historyId` is the ID of the currently playing track, i.e.
 `mp.historyEntry().id`.
 
@@ -1609,6 +1611,15 @@ all numbers:
 ### entry.getUser(): Promise&lt;[User](#class-user)>
 
 Get the full user object of the user who played this song.
+
+<a id="historyentry-skip"></a>
+### entry.skip(): Promise
+
+Skip this play.
+
+```js
+mp.historyEntry().skip()
+```
 
 <a id="class-storeproduct"></a>
 ## StoreProduct

--- a/src/data/historyEntry.js
+++ b/src/data/historyEntry.js
@@ -15,6 +15,7 @@ export default function wrapHistoryEntry (mp, raw) {
   }
 
   return makeProto(entry, {
-    getUser: partial(mp.getUser, raw.user.id)
+    getUser: partial(mp.getUser, raw.user.id),
+    skip: partial(mp.skipDJ, raw.user.id, raw.id)
   })
 }


### PR DESCRIPTION
Rather than having to do

```js
mp.dj().skip(mp.historyEntry().id)
```

this instead allows you to do
```js
mp.historyEntry().skip()
```

the actual thing you're trying to do is skip a play, not skip a user, so I think the second way makes more sense.