### PR TITLE
historyEntry consistency addressing #96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.13.1 / 22 Feb 2018
+
+Bugfixes:
+
+ * Some historyEntries would not have the #skip() method (#96)
+
 # 1.13.0 / 04 Nov 2017
 
 Features:

--- a/docs/API.md
+++ b/docs/API.md
@@ -167,6 +167,7 @@
    - [entry.timestamp](#historyentry-timestamp)
    - [entry.score](#historyentry-score)
    - [entry.getUser()](#historyentry-getuser)
+   - [entry.skip()](#historyentry-skip)
  - [StoreProduct](#class-storeproduct)
    - [product.type](#storeproduct-type)
    - [product.category](#storeproduct-category)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "miniplug",
   "description": "Teeny-tiny plug.dj library/API",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "license": "MIT",
   "main": "index.js",
   "module": "index.es.js",

--- a/src/data/historyEntry.js
+++ b/src/data/historyEntry.js
@@ -1,21 +1,21 @@
 import makeProto from '../wrap'
 import { partial, parseDate } from '../util'
 
-export default function wrapHistoryEntry (mp, raw) {
-  const timestamp = parseDate(raw.timestamp)
-  const entry = {
-    id: raw.id,
-    // wrapMedia expects a playlist ID, but we don't know it--pass null instead.
-    media: mp.wrapMedia(null, raw.media),
-    room: mp.wrapRoom(raw.room),
-    user: mp.wrapUser(raw.user),
-    time: timestamp, // TODO(v2.x) remove this alias
-    timestamp: timestamp,
-    score: raw.score
+export default function wrapHistoryEntry (mp, rawEntry) {
+  const timestamp = parseDate(rawEntry.timestamp)
+
+  rawEntry.timestamp = timestamp
+  rawEntry.time = timestamp // TODO(v2.x) remove this alias
+  // wrapMedia expects a playlist ID, but we don't know it--pass null instead.
+  rawEntry.media = mp.wrapMedia(null, rawEntry.media)
+  rawEntry.user = mp.wrapUser(rawEntry.user)
+
+  if (rawEntry.room) {
+    rawEntry.room = mp.wrapRoom(rawEntry.room)
   }
 
-  return makeProto(entry, {
-    getUser: partial(mp.getUser, raw.user.id),
-    skip: partial(mp.skipDJ, raw.user.id, raw.id)
+  return makeProto(rawEntry, {
+    getUser: partial(mp.getUser, rawEntry.user.id),
+    skip: partial(mp.skipDJ, rawEntry.user.id, rawEntry.id)
   })
 }

--- a/src/plugins/booth.js
+++ b/src/plugins/booth.js
@@ -11,14 +11,20 @@ export default function boothPlugin (opts = {}) {
 
     mp.on('roomState', (state) => {
       const timestamp = parseDate(state.playback.startTime)
-      mp[kCurrentHistoryEntry] = {
+
+      mp[kCurrentHistoryEntry] = mp.wrapHistoryEntry({
         id: state.playback.historyID,
-        dj: mp.user(state.booth.currentDJ),
-        media: state.playback.media,
-        playlistId: state.playback.playlistID,
-        time: timestamp, // TODO(v2.x) remove this alias
+        user: mp.user(state.booth.currentDJ),
+        media: media,
         timestamp: timestamp
-      }
+      })
+
+      // only for the current historyEntry
+      mp[kCurrentHistoryEntry].playlistId = state.playback.playlistID
+
+      // Compat with v1.7.0 and below.
+      // TODO remove in 2.x
+      mp[kCurrentHistoryEntry].dj = mp[kCurrentHistoryEntry].user
     })
 
     // Socket API
@@ -45,7 +51,7 @@ export default function boothPlugin (opts = {}) {
         timestamp: timestamp
       })
 
-      // single occurrence
+      // only for the current historyEntry
       mp[kCurrentHistoryEntry].playlistId = playlistId
 
       // Compat with v1.7.0 and below.

--- a/src/plugins/booth.js
+++ b/src/plugins/booth.js
@@ -35,19 +35,18 @@ export default function boothPlugin (opts = {}) {
         m: media,
         c: djId,
         p: playlistId,
-        t: time
+        t: timestamp
       } = event
 
-      time = parseDate(time)
-
-      mp[kCurrentHistoryEntry] = {
+      mp[kCurrentHistoryEntry] = mp.wrapHistoryEntry({
         id: historyId,
         user: mp.user(djId) || mp.wrapUser({ id: djId }),
         media: media,
-        playlistId: playlistId,
-        time: time, // TODO(v2.x) remove this alias
-        timestamp: time
-      }
+        timestamp: timestamp
+      })
+
+      // single occurrence
+      mp[kCurrentHistoryEntry].playlistId = playlistId
 
       // Compat with v1.7.0 and below.
       // TODO remove in 2.x


### PR DESCRIPTION
All historyEntries now follow the same format and should have the same properties.

Gonna leave it for review then squash+merge and publish+release.